### PR TITLE
Minor bugfix to fix hardcode and fix trajectoryHeatmap function

### DIFF
--- a/R/grn.R
+++ b/R/grn.R
@@ -8,6 +8,7 @@
 #' @param gene.use A string list to specify which genes to use for correlation computation
 #' @param tf.assay Assay that includes TF activity data. Default: "chromvar"
 #' @param gene.assay Assay that includes gene expression activity data. Default: "RNA"
+#' @param atac.assay Assay that includes peaks data. Default: "ATAC"
 #' @param trajectory.name Trajectory name
 #'
 #' @return A matrix containing TF-gene correlation
@@ -18,6 +19,7 @@ GetTFGeneCorrelation <- function(object,
                                  gene.use = NULL,
                                  tf.assay = "chromvar",
                                  gene.assay = "RNA",
+                                 atac.assay="ATAC",
                                  trajectory.name = "Trajectory") {
   ## get tf activity and gene expression along trajectory
   trajMM <- GetTrajectory(
@@ -38,7 +40,7 @@ GetTFGeneCorrelation <- function(object,
     log2Norm = TRUE
   )
 
-  rownames(trajMM) <- object@assays$ATAC@motifs@motif.names
+  rownames(trajMM) <- object@assays[[atac.assay]]@motifs@motif.names
 
   tf_activity <- suppressMessages(
     TrajectoryHeatmap(

--- a/R/select_tf_gene.R
+++ b/R/select_tf_gene.R
@@ -3,6 +3,7 @@
 #' @param object A Seurat object
 #' @param tf.assay The assay name for TF activity. Default: "chromvar"
 #' @param rna.assay The assay name for gene expression. Default: "RNA"
+#' @param atac.assay The assay name for Peaks. Default: "ATAC"
 #' @param trajectory.name The trajectory name used for computing correlation
 #' between TF binding activity and TF expression
 #' @param p.cutoff A cutoff of p-values. Default: 0.01
@@ -16,6 +17,7 @@
 SelectTFs <- function(object,
                       tf.assay = "chromvar",
                       rna.assay = "RNA",
+                      atac.assay= "ATAC",
                       trajectory.name = "Trajectory",
                       p.cutoff = 0.01,
                       cor.cutoff = 0.3,
@@ -29,7 +31,7 @@ SelectTFs <- function(object,
     log2Norm = FALSE
   )) 
 
-  rownames(trajMM) <- object@assays$ATAC@motifs@motif.names
+  rownames(trajMM) <- object@assays[[atac.assay]]@motifs@motif.names
 
   trajRNA <- suppressMessages(GetTrajectory(
     object,
@@ -116,7 +118,9 @@ SelectGenes <- function(object,
                         fdr.cutoff = 1e-04,
                         return.heatmap = TRUE,
                         labelTop1 = 10,
-                        labelTop2 = 10) {
+                        labelTop2 = 10,
+                        genome = "hg38"
+                        ) {
   trajRNA <- GetTrajectory(
     object,
     assay = rna.assay,
@@ -159,7 +163,7 @@ SelectGenes <- function(object,
   message("Linking cis-regulatory elements to genes...")
   df.p2g <- PeakToGene(peak.mat = groupMatATAC,
                        gene.mat = groupMatRNA,
-                       genome = "hg38")
+                       genome = genome)
 
   df.p2g <- df.p2g %>%
     subset(distance > distance.cutoff) %>%

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -7,6 +7,7 @@
 #' @param tf.use Which TF to plot.
 #' @param tf.assay Assay name for TF binding activity. Default: "chromvar"
 #' @param rna.assay Assay name for TF expression. Default: "RNA"
+#' @param atac.assay Assay name for Peaks. Default: "ATAC"
 #' @param target.assay Assay name for TF target expression. Default: "target"
 #' @param trajectory.name Trajectory name for visualization.
 #'
@@ -16,6 +17,7 @@
 PseudotimePlot <- function(object, tf.use,
                            tf.assay="chromvar",
                            rna.assay = "RNA",
+                           atac.assay = "ATAC",
                            target.assay = "target",
                            trajectory.name = "Trajectory"){
 
@@ -27,7 +29,7 @@ PseudotimePlot <- function(object, tf.use,
         log2Norm = FALSE
     ))
 
-    rownames(trajMM) <- object@assays$ATAC@motifs@motif.names
+    rownames(trajMM) <- object@assays[[atac.assay]]@motifs@motif.names
 
     df.tf.activity <- assay(trajMM)
     df.tf.activity <- t(scale(t(df.tf.activity)))
@@ -557,6 +559,12 @@ TrajectoryHeatmap <- function(trajectory,
   if (sum(rSNA > 0) > 0) {
     message("Removing rows with NA values...")
     mat <- mat[rSNA == 0, ]#Remove NA Rows
+  }
+  #colum all zero
+  rSZero <- which(matrixStats::rowSds(mat) != 0)
+  if(length(rSZero) < nrow(mat)){
+    message("Removing rows without peaks...")
+    mat <- mat[rSZero, ]#Remove 0 Rows
   }
 
   varQ <- ArchR:::.getQuantiles(matrixStats::rowVars(mat))

--- a/man/GetTFGeneCorrelation.Rd
+++ b/man/GetTFGeneCorrelation.Rd
@@ -10,6 +10,7 @@ GetTFGeneCorrelation(
   gene.use = NULL,
   tf.assay = "chromvar",
   gene.assay = "RNA",
+  atac.assay = "ATAC",
   trajectory.name = "Trajectory"
 )
 }
@@ -23,6 +24,8 @@ GetTFGeneCorrelation(
 \item{tf.assay}{Assay that includes TF activity data. Default: "chromvar"}
 
 \item{gene.assay}{Assay that includes gene expression activity data. Default: "RNA"}
+
+\item{atac.assay}{Assay that includes peaks data. Default: "ATAC"}
 
 \item{trajectory.name}{Trajectory name}
 }

--- a/man/PseudotimePlot.Rd
+++ b/man/PseudotimePlot.Rd
@@ -9,6 +9,7 @@ PseudotimePlot(
   tf.use,
   tf.assay = "chromvar",
   rna.assay = "RNA",
+  atac.assay = "ATAC",
   target.assay = "target",
   trajectory.name = "Trajectory"
 )
@@ -21,6 +22,8 @@ PseudotimePlot(
 \item{tf.assay}{Assay name for TF binding activity. Default: "chromvar"}
 
 \item{rna.assay}{Assay name for TF expression. Default: "RNA"}
+
+\item{atac.assay}{Assay name for Peaks. Default: "ATAC"}
 
 \item{target.assay}{Assay name for TF target expression. Default: "target"}
 

--- a/man/SelectGenes.Rd
+++ b/man/SelectGenes.Rd
@@ -15,7 +15,8 @@ SelectGenes(
   fdr.cutoff = 1e-04,
   return.heatmap = TRUE,
   labelTop1 = 10,
-  labelTop2 = 10
+  labelTop2 = 10,
+  genome = "hg38"
 )
 }
 \arguments{

--- a/man/SelectTFs.Rd
+++ b/man/SelectTFs.Rd
@@ -8,6 +8,7 @@ SelectTFs(
   object,
   tf.assay = "chromvar",
   rna.assay = "RNA",
+  atac.assay = "ATAC",
   trajectory.name = "Trajectory",
   p.cutoff = 0.01,
   cor.cutoff = 0.3,
@@ -20,6 +21,8 @@ SelectTFs(
 \item{tf.assay}{The assay name for TF activity. Default: "chromvar"}
 
 \item{rna.assay}{The assay name for gene expression. Default: "RNA"}
+
+\item{atac.assay}{The assay name for Peaks. Default: "ATAC"}
 
 \item{trajectory.name}{The trajectory name used for computing correlation
 between TF binding activity and TF expression}


### PR DESCRIPTION
1. Hard code, when set TF names, using Assay name from ATAC assay
2. Hard code, hg38 for genome.
3. Fix the bug when there's no expression for the TrajectoryHeatmap function.